### PR TITLE
Refactor Provider::mapUserToObject()

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -196,7 +196,7 @@ class Provider extends AbstractProvider
     protected function mapUserToObject(array $user)
     {
         $requestValue = request('user');
-        if (! is_bool($requestValue) && ! is_array($requestValue) && trim((string) $requestValue) !== '') {
+        if (is_bool($requestValue) || is_array($requestValue) || trim((string) $requestValue) !== '') {
             $userRequest = json_decode(request('user'), true);
 
             if (array_key_exists('name', $userRequest)) {

--- a/Provider.php
+++ b/Provider.php
@@ -195,7 +195,8 @@ class Provider extends AbstractProvider
      */
     protected function mapUserToObject(array $user)
     {
-        if (request()->filled('user')) {
+        $requestValue = request('user');
+        if (! is_bool($requestValue) && ! is_array($requestValue) && trim((string) $requestValue) === '') {
             $userRequest = json_decode(request('user'), true);
 
             if (array_key_exists('name', $userRequest)) {

--- a/Provider.php
+++ b/Provider.php
@@ -196,7 +196,7 @@ class Provider extends AbstractProvider
     protected function mapUserToObject(array $user)
     {
         $requestValue = request('user');
-        if (! is_bool($requestValue) && ! is_array($requestValue) && trim((string) $requestValue) === '') {
+        if (! is_bool($requestValue) && ! is_array($requestValue) && trim((string) $requestValue) !== '') {
             $userRequest = json_decode(request('user'), true);
 
             if (array_key_exists('name', $userRequest)) {


### PR DESCRIPTION
Removed the call to filled() as it throws a BadMethodCallException in Laravel 5.4 and replace it with the same checks that the filled() method uses in Laravel >=5.5

this is necessary because this library has a dependency to socialiteproviders/manager which allows installation in laravel 5.4 in the latest version